### PR TITLE
Fix and clean up cross-references

### DIFF
--- a/sources/2.2.0/sections/01-overview.adoc
+++ b/sources/2.2.0/sections/01-overview.adoc
@@ -20,7 +20,7 @@ This document describes an S-100 compliant product specification for a bathymetr
 
 * [[[iso-639-2,ISO 639-2:1998]]]
 
-* [[[iso-ts-19103,ISO/TS 19103:2015]]]
+* [[[iso-19103,ISO 19103:2015]]]
 
 * [[[iso-19111,ISO 19111:2007]]]
 
@@ -44,7 +44,7 @@ This document describes an S-100 compliant product specification for a bathymetr
 
 * [[[iso-ts-19130-2,ISO/TS 19130-2:2014]]]
 
-* [[[iso19139-1,ISO/TS 19139-1:2019]]]
+* [[[iso-19139-1,ISO/TS 19139-1:2019]]]
 
 * [[[iso-10646-1,ISO/IEC 10646-1:2000]]]
 

--- a/sources/2.2.0/sections/03-data_product_id.adoc
+++ b/sources/2.2.0/sections/03-data_product_id.adoc
@@ -47,6 +47,6 @@ Main topics for the product, as according to <<iso-19115-1>> MD_TopicCategoryCod
 Chair has action to draft a request to S-100 to add an "Other" designation. Selection of "Other" would be accompanied by a free text description of the not-otherwise-specified designation.
 ****
 
-*Spatial Representation Type*:: Type of spatial representation for the product, as defined by the <<iso19115>> MD_SpatialRepresentationTypeCode: 002 - grid.
+*Spatial Representation Type*:: Type of spatial representation for the product, as defined by the <<iso-19115-1>> MD_SpatialRepresentationTypeCode: 002 - grid.
 
 *Point of Contact*:: Producing Agency

--- a/sources/2.2.0/sections/04-data_content_struct.adoc
+++ b/sources/2.2.0/sections/04-data_content_struct.adoc
@@ -24,7 +24,7 @@ The model in <<fig-data-set-structure-s102>> states that:
 
 * An S-102 data set (*S102_DataSet*), which is inherited from *S100_DataSet*, references an S-102 Image and Gridded Data Collection (*S102_IGCollection*). In S-100 it is possible to have multiple collections but in S-102 only one is needed to hold the bathymetry coverage. The S-102 discovery metadata class (*S102_DiscoveryMetadata*) describes the metadata entities required for the identification of the entire data set. The required discovery metadata is implemented through the *S102_DSMetadataBlock* class.
 
-* An instance of an S-102 Image and Gridded Data Collection (*S102_IGCollection*) which is a subtype of *S100_IGCollection*, is described by a set of S-102 Collection Metadata (*S102_CollectionMetadata*). This relationship is 1 to 1 meaning that there is one set of collection metadata for each instance of *S102_IGCollection*. There is a large choice of metadata that may be used in an S-100 compliant data product. Only a small amount of this metadata is mandated by <<iso19115>> for discovery. The choice of metadata is discussed in <<subsec-discovery-metadata>>. Much of the metadata can be resolved as part of the product specification. Only that metadata that varies IG_collection item to item needs be included in the S102_MetadataBlock implementation class.
+* An instance of an S-102 Image and Gridded Data Collection (*S102_IGCollection*) which is a subtype of *S100_IGCollection*, is described by a set of S-102 Collection Metadata (*S102_CollectionMetadata*). This relationship is 1 to 1 meaning that there is one set of collection metadata for each instance of *S102_IGCollection*. There is a large choice of metadata that may be used in an S-100 compliant data product. Only a small amount of this metadata is mandated by <<iso-19115-1>> for discovery. The choice of metadata is discussed in <<subsec-discovery-metadata>>. Much of the metadata can be resolved as part of the product specification. Only that metadata that varies IG_collection item to item needs be included in the S102_MetadataBlock implementation class.
 
 This matter is discussed further in <<subsec-tiling-scheme-partitioning>>.
 
@@ -88,7 +88,7 @@ The attribute _origin_ has the value class _DirectPosition_ which is a position 
 [level=7]
 ===== offsetVectors
 
-The attribute _offsetVectors_ has the value class _Sequence<Vector>_ that shall be a sequence of offset vector elements that determine the grid spacing in each direction. The data type Vector is specified in <<iso-ts-19103>>. This attribute is required. There is no default. The HDF5 encoding implements and simplifies _offsetVectors_ in the form of two HDF5 attributes: gridSpacingLatitudinal and gridSpacingLongitudinal.
+The attribute _offsetVectors_ has the value class _Sequence<Vector>_ that shall be a sequence of offset vector elements that determine the grid spacing in each direction. The data type Vector is specified in <<iso-19103>>. This attribute is required. There is no default. The HDF5 encoding implements and simplifies _offsetVectors_ in the form of two HDF5 attributes: gridSpacingLatitudinal and gridSpacingLongitudinal.
 
 [level=7]
 ===== dimension

--- a/sources/2.2.0/sections/05-coord_ref_system.adoc
+++ b/sources/2.2.0/sections/05-coord_ref_system.adoc
@@ -29,7 +29,7 @@ h|EPSG Code h|Coordinate Reference System
 *Projection*:: NONE/UTM/UPS
 *Temporal reference system*:: Gregorian Calendar
 *Coordinate Reference System registry*:: link:http://www.epsg-registry.org/[EPSG Geodetic Parameter Registry]
-*Date type (according to <<iso19115-1>>)*:: 002 - publication
+*Date type (according to <<iso-19115-1>>)*:: 002 - publication
 *Responsible party*:: International Organisation of Oil and Gas Producers (OGP)
 *URL*:: http://www.ogp.org.uk/
 

--- a/sources/2.2.0/sections/07-data_cap_class.adoc
+++ b/sources/2.2.0/sections/07-data_cap_class.adoc
@@ -4,6 +4,7 @@ The Data Classification and Encoding Guide (DCEG) describes how data describing 
 
 There are a number of sounding techniques, including sonar and lidar that are used to capture bathymetric data. It is permitted, but not required, to include data acquisition information in the metadata of an S-102 Bathymetric Surface product. The metadata class S102_AcquisitionMetadata has been defined, but the information elements to populate this metadata class should be identified in a national profile of S-102.
 
+[[qualityAndSourceMetadata]]
 === Quality and source metadata
 
 Quality and source metadata in S-102 are intended to enable and support future navigation software to appropriately auto-generate and attribute cartographic features such as custom depth contours and soundings from S-102 products, all while minimally impacting the overall file size of the product.
@@ -24,4 +25,4 @@ Quality and source metadata in S-102 are based on S-101 quality attributes, with
 
 . Prevent the automated selection of soundings from interpolated nodes, while still providing continuous data required or depth contour creation. This is done by the "bathyCoverage" Boolean attribute field, which flags nodes populated by interpolation across gaps of bathymetric observations greater than the S-102 raster resolution. This is especially useful in side-scan surveys which are characterized by gaps in bathymetric observations with full coverage side-scan imagery (interpolated gaps between bathymetry coverage in this situation would show fullCoverage = True and bathyCoverage = False). If full coverage = False, bathyCoverage must also equal False, such as gaps between single beam echosounder data without correlating side scan sonar coverage. Thus, this will provide navigation software systems with the required information necessary to preferably select soundings from direct bathymetric observations.
 
-Quality and source metadata are encoded as records within a QualityOfSurveyCoverage information group, dataset featureAttributeTable (<<cls-10.2.7>>).
+Quality and source metadata are encoded as records within a QualityOfSurveyCoverage information group, dataset featureAttributeTable (<<tab-attributes-of-values-group>>).

--- a/sources/2.2.0/sections/10-data_product_format.adoc
+++ b/sources/2.2.0/sections/10-data_product_format.adoc
@@ -828,6 +828,7 @@ For bathymetric gridded data, the dataset includes a two-dimensional array conta
 
 The depth and uncertainty values (depth and uncertainty) are stored in two-dimensional arrays with a prescribed number of columns (numCOL) and rows (numROW). This grid is defined as a regular grid (dataCodingFormat = 2); therefore, the depth and uncertainty values will be for each discrete point in the grid. The data type of the array values is a compound with two members.
 
+[[root-qualityOfSurveyCoverage]]
 ==== Root QualityOfSurveyCoverage
 
 The QualityOfSurveyCoverage container group has the same metadata attributes as BathymetryCoverage container group (see <<tab-attributes-of-bathymetrycoverage-feature-container-group>>). The values of the attributes must also be the same as the BathymetryCoverage container group.

--- a/sources/2.2.0/sections/10-data_product_format.adoc
+++ b/sources/2.2.0/sections/10-data_product_format.adoc
@@ -559,7 +559,7 @@ BathymetryCoverage and QualityOfSurveyCoverage are arrays of compound type eleme
 |geSemiInterval
 |===
 
-According to <<iho-2100,part=10c,clause=9.5>>, "All the numeric values in the feature description dataset are string representations of numeric values; for example, "-9999.0" not the float value -9999.0."
+According to <<iho-100,part=10c,clause=9.5>>, "All the numeric values in the feature description dataset are string representations of numeric values; for example, "-9999.0" not the float value -9999.0."
 
 While the sample contents are shown in the two attributes columns, these are actually rows in the BathymetryCoverage table. They are also each a single HDF5 compound type and represent a single HDF5 element in the table.
 

--- a/sources/2.2.0/sections/10-data_product_format.adoc
+++ b/sources/2.2.0/sections/10-data_product_format.adoc
@@ -599,7 +599,7 @@ unsigned +
 | commonPointRule
 | 1
 | Enumeration
-| Value: 1 (average) or other values from <<iho-s100,part-10c>> Table 20.
+| Value: 1 (average) or other values from <<iho-s100,part-10c,table=20>>.
 
 | 4
 | Horizontal position uncertainty

--- a/sources/2.2.0/sections/10-data_product_format.adoc
+++ b/sources/2.2.0/sections/10-data_product_format.adoc
@@ -15,7 +15,7 @@ The S-102 data set must be encoded using the Hierarchical Data Format standard, 
 
 The key idea behind the S-102 product structure is that each coverage is a feature. Each of these features is co-located with the others. Therefore, they share the same spatial metadata and each is required to correctly interpret the others.
 
-For the use of HDF5, the following key concepts (<<iho-s100,part=10c>> clause 5.1) are important:
+For the use of HDF5, the following key concepts (<<iho-s100,part=10c,clause=5.1>>) are important:
 
 _File_:: a contiguous string of bytes in a computer store (memory, disk, etc.), and the bytes represent zero or more objects of the model;
 
@@ -51,7 +51,7 @@ image::figure-outline-of-the-generic-data-file-structure.png[]
 
 *Level 4*:: This level contains the actual data for each feature. In S-102 the BathymetryCoverage uses the ValuesGroup to define the content. The other groups at this level are not used.
 
-In <<tab-overview-of-s102-data-product>> below, levels refer to HDF5 structuring (see <<iho-s100,part=10c>>, Figure 9). Naming in each box below the header line is as follows: Generic name; S-100 or S-102 name, or nothing if none; and (_HDF5 type_) group, attribute or attribute list, or dataset. <<fig-hierarchy-of-s102-data-product>> depicts the same structure using a graphical representation.
+In <<tab-overview-of-s102-data-product>> below, levels refer to HDF5 structuring (see <<iho-s100,part=10c,figure=9>>). Naming in each box below the header line is as follows: Generic name; S-100 or S-102 name, or nothing if none; and (_HDF5 type_) group, attribute or attribute list, or dataset. <<fig-hierarchy-of-s102-data-product>> depicts the same structure using a graphical representation.
 
 
 [[tab-overview-of-s102-data-product]]
@@ -184,7 +184,7 @@ The root group is required by HDF5. The S-100 HDF5 format (<<iho-s100,part=10c>>
 | productSpecification
 ^| 1
 <| String
-| <<iho-s100,part=10c>>, Table 6 +
+| <<iho-s100,part=10c,table=6>> +
 Example: INT.IHO.S-102.2.2
 
 | 2
@@ -222,7 +222,7 @@ Example: INT.IHO.S-102.2.2
 ^| 0..1
 <| Enumeration
 | Mandatory if horizontalCRS = -1 +
-See <<iho-s100,part=10c>> clause 5.
+See <<iho-s100,part=10c,clause=5>>.
 
 | 7
 | Horizontal coordinate system
@@ -281,7 +281,7 @@ EPSG Code
 32-bit
 | Mandatory if typeOfHorizontalCRS = 2; +
 EPSG Code +
-See <<iho-s100,part=10c>> clause 8.
+See <<iho-s100,part=10c,clause=8>>.
 
 | 13
 | Projection parameter 1
@@ -290,7 +290,7 @@ See <<iho-s100,part=10c>> clause 8.
 <| Float +
 64-bit
 | Only if projectionMethod is used. +
-See <<iho-s100,part=10c>> clause 8.
+See <<iho-s100,part=10c,clause=8>>.
 
 | 14
 | Projection parameter 2
@@ -299,7 +299,7 @@ See <<iho-s100,part=10c>> clause 8.
 <| Float +
 64-bit
 | Only if projectionMethod is used. +
-See <<iho-s100,part=10c>> clause 8.
+See <<iho-s100,part=10c,clause=8>>.
 
 | 15
 | Projection parameter 3
@@ -308,7 +308,7 @@ See <<iho-s100,part=10c>> clause 8.
 <| Float +
 64-bit
 | Only if projectionMethod is used. +
-See <<iho-s100,part=10c>> clause 8.
+See <<iho-s100,part=10c,clause=8>>.
 
 | 16
 | Projection parameter 4
@@ -317,7 +317,7 @@ See <<iho-s100,part=10c>> clause 8.
 <| Float +
 64-bit
 | Only if projectionMethod is used. +
-See <<iho-s100,part=10c>> clause 8.
+See <<iho-s100,part=10c,clause=8>>.
 
 | 17
 | Projection parameter 5
@@ -326,7 +326,7 @@ See <<iho-s100,part=10c>> clause 8.
 <| Float +
 64-bit
 | Only if projectionMethod is used. +
-See <<iho-s100,part=10c>> clause 8.
+See <<iho-s100,part=10c,clause=8>>.
 
 | 18
 | False northing
@@ -392,7 +392,7 @@ If a projected CRS is used for the dataset, these values refer to those of the b
 <| String
 | Name of metadata file +
 MD_<HDF5 data file base name>.XML (or .xml) ISO metadata +
-(per <<iho-s100,part=10c>> clause 12).
+(per <<iho-s100,part=10c,clause=12>>).
 
 | 23
 | Vertical coordinate system
@@ -414,7 +414,7 @@ Allowed values: +
 <| Enumeration
 | Mandatory in S-102. +
 The only allowed value is 2: verticalDatum +
-(see <<iho-s100,part=10c>> clause 6).
+(see <<iho-s100,part=10c,clause=6>>).
 
 | 25
 | Vertical datum reference
@@ -423,7 +423,7 @@ The only allowed value is 2: verticalDatum +
 <| Enumeration
 | Mandatory in S-102. +
 The only allowed value is 1: s100VerticalDatum +
-(see <<iho-s100,part=10c>> clause 7).
+(see <<iho-s100,part=10c,clause=7>>).
 
 | 26
 | Vertical datum
@@ -456,7 +456,7 @@ The remark in S-100 Edition 5.0.0 is outdated. The _productIdentifier_ ("S-102")
 [[note2]]
 [NOTE]
 ====
-The value horizontalCRS specifies the horizontal Coordinate Reference System. At the time of writing, S-100 does not yet provide a mechanism for this value's definition within HDF5 encoding (such as an enumeration of horizontal CRSs). Consequently, this configuration causes a deviation from S-100. The horizontal datum is implicitly defined by this CRS because each horizontal CRS consists of a coordinate system and a datum. S-102 does not use "user defined" CRS as mentioned in <<iho-s100,part=10c>> Table 6.
+The value horizontalCRS specifies the horizontal Coordinate Reference System. At the time of writing, S-100 does not yet provide a mechanism for this value's definition within HDF5 encoding (such as an enumeration of horizontal CRSs). Consequently, this configuration causes a deviation from S-100. The horizontal datum is implicitly defined by this CRS because each horizontal CRS consists of a coordinate system and a datum. S-102 does not use "user defined" CRS as mentioned in <<iho-s100,part=10c,table=6>>.
 ====
 
 //Tentative, TBD. If so-called “user defined crs” is also allowed in order to encode projection parameters in the HDF5 dataset, #s 5-19 from S-100 Table 10c-6 will have to be added to the table. (RM comment from 4Jan2023)
@@ -466,7 +466,7 @@ The value horizontalCRS specifies the horizontal Coordinate Reference System. At
 [[note3]]
 [NOTE]
 ====
-The baseCRS is the geodetic CRS on which the projected CRS is based. In particular, the datum of the base CRS is also used for the derived CRS (see <<iho-s100,part=6>> Table 6).
+The baseCRS is the geodetic CRS on which the projected CRS is based. In particular, the datum of the base CRS is also used for the derived CRS (see <<iho-s100,part=6,table=6>>).
 ====
 
 ===== Gridding method
@@ -481,9 +481,9 @@ This group specifies the S-100 features to which the data applies, and consists 
 
 *featureCode* -- a 1-dimesional dataset with the featureCode(s) of the S-100 feature(s) contained in the data product. For S-102, the dataset has only two elements -- the string "*BathymetryCoverage*" and "*QualityOfSurveyCoverage*" (without quotes). The entries in this dataset give the names of the other two components of Group_F.
 
-*BathymetryCoverage* -- A 1-dimensional dataset that contains the standard definition of the bathymetry coverage feature class in terms of its attributes and their types, units of measure, etc. The datatype of its elements is the compound type described in <<iho-s100,part=10c>> Table 8. 
+*BathymetryCoverage* -- A 1-dimensional dataset that contains the standard definition of the bathymetry coverage feature class in terms of its attributes and their types, units of measure, etc. The datatype of its elements is the compound type described in <<iho-s100,part=10c,table=8>>.
 
-*QualityOfSurveyCoverage* -- A 1-dimensional dataset of the same datatype as the *BathymetryCoverage* dataset described above. This *QualityOfSurveyCoverage* dataset contains the definition of the reference to metadata records. The reference is a single integer which identifies a metadata record in _featureAttributeTable_ (described in <<iho-s100,part=10c>> clause 9.6.2 and <<root-qualityOfSurveyCoverage>>.
+*QualityOfSurveyCoverage* -- A 1-dimensional dataset of the same datatype as the *BathymetryCoverage* dataset described above. This *QualityOfSurveyCoverage* dataset contains the definition of the reference to metadata records. The reference is a single integer which identifies a metadata record in _featureAttributeTable_ (described in <<iho-s100,part=10c,clause=9.6.2>> and <<root-qualityOfSurveyCoverage>>.
 
 //QualityOfBathymetricData is defined in the GI Registry as “An area within which a uniform assessment of the quality of the bathymetric data exists.” That does not describe this dataset, which provides information at the level of individual cells. Recommend new type QualityOfSurveyCoverage or QualityOfBathymetryCoverage, defined as “A set of references to value records that provide localised information about depths, uncertainties, and survey metadata.”
 It can be proposed to the GI Registry after the S-102 team approves it. (RM comment 23Jan2023)
@@ -559,7 +559,7 @@ BathymetryCoverage and QualityOfSurveyCoverage are arrays of compound type eleme
 |geSemiInterval
 |===
 
-According to <<iho-2100,part=10c>> clause 9.5, "All the numeric values in the feature description dataset are string representations of numeric values; for example, "-9999.0" not the float value -9999.0."
+According to <<iho-2100,part=10c,clause=9.5>>, "All the numeric values in the feature description dataset are string representations of numeric values; for example, "-9999.0" not the float value -9999.0."
 
 While the sample contents are shown in the two attributes columns, these are actually rows in the BathymetryCoverage table. They are also each a single HDF5 compound type and represent a single HDF5 element in the table.
 
@@ -632,7 +632,7 @@ unsigned +
 ^| 1
 | Enumeration
 | Value: 1 (linear) +
-see <<iho-s100,part=10c>> Table 21.
+see <<iho-s100,part=10c,table=21>>.
 
 | 7b
 
@@ -647,12 +647,12 @@ For example, "latitude,longitude". Reverse scan direction along an axis is indic
 | interpolationType
 | 1
 | Enumeration
-| Code value from <<iho-s100,part=10c>> Table 22
+| Code value from <<iho-s100,part=10c,table=22>>
 
 |===
 
 ==== Feature Instance group -- BathymetryCoverage.01
-Per <<iho-s100,part=10c>> clause 9.7 and <<iho-s100,part=10c>> Table 12: Attributes of feature instance groups
+Per <<iho-s100,part=10c,clause=9.7>> and <<iho-s100,part=10c,table=12>>: Attributes of feature instance groups
 
 [[tab-attributes-of-bathymetrycoverage-feature-instance-group]]
 [cols="<,<,<,^,<,<"]
@@ -833,7 +833,7 @@ The depth and uncertainty values (depth and uncertainty) are stored in two-dimen
 
 The QualityOfSurveyCoverage container group has the same metadata attributes as BathymetryCoverage container group (see <<tab-attributes-of-bathymetrycoverage-feature-container-group>>). The values of the attributes must also be the same as the BathymetryCoverage container group.
 
-The QualityOfSurveyCoverage container group contains an additional 1-dimensional array named featureAttributeTable (<<iho-s100,part=10c>> Table 9; <<iho-s100,part=10c>> clause 9.6.2). This dataset is mandatory within the QualityOfSurveyCoverage group. Each element of this array is a metadata record of HDF5 compound type. The fields are described in <<tab-elements-of-featureAttributeTable-compound-datatype>> below.
+The QualityOfSurveyCoverage container group contains an additional 1-dimensional array named featureAttributeTable (<<iho-s100,part=10c,table=9>>; <<iho-s100,part=10c,clause=9.6.2>>). This dataset is mandatory within the QualityOfSurveyCoverage group. Each element of this array is a metadata record of HDF5 compound type. The fields are described in <<tab-elements-of-featureAttributeTable-compound-datatype>> below.
 
 //(1) Are these fields mandatory? (2) Can producers add other fields like surveyType and line spacing? (RM comment 4Jan2023)
 //All optional except id. Producers should not add other fields. (RM comment 23Jan2023)
@@ -960,7 +960,7 @@ See <<note9>>.
 | String
 | ISO 8602:2004 date format. +
 Complete or truncated date, +
-see <<iho-s100,part=1>> Table 2.
+see <<iho-s100,part=1,table=2>>.
 
 | 12
 | surveyDateRange.dateEnd
@@ -969,7 +969,7 @@ see <<iho-s100,part=1>> Table 2.
 | String
 | ISO 8602:2004 date format. +
 Complete or truncated date, +
-see <<iho-s100,part=1>> Table 2.
+see <<iho-s100,part=1,table=2>>.
 
 | 13
 | sourceSurveyID

--- a/sources/2.2.0/sections/12-metadata.adoc
+++ b/sources/2.2.0/sections/12-metadata.adoc
@@ -3,13 +3,13 @@
 == Metadata
 
 === Introduction
-The Metadata elements used in the Bathymetric Surface product are derived from S-100 and from <<iso19115>> and <<iso-19115-2>>. Optionally additional metadata may be derived from <<iso-ts-19130>> and <<iso-ts-19130-2>> especially metadata relating to the sonar equipment which may have been used to acquire the bathymetric data.
+The Metadata elements used in the Bathymetric Surface product are derived from S-100 and from <<iso-19115-1>> and <<iso-19115-2>>. Optionally additional metadata may be derived from <<iso-ts-19130>> and <<iso-ts-19130-2>> especially metadata relating to the sonar equipment which may have been used to acquire the bathymetric data.
 
-There are only a few elements in the <<iso19115>> metadata standard that are mandatory and these relate only to the use of the metadata for identification and pedigree of the data set. A minimum level of data identification is required for all applications including database applications, web services and data set production. However, S-102 requires certain metadata attributes which are used to geolocate the dataset as well as establish a pedigree for the data.
+There are only a few elements in the <<iso-19115-1>> metadata standard that are mandatory and these relate only to the use of the metadata for identification and pedigree of the data set. A minimum level of data identification is required for all applications including database applications, web services and data set production. However, S-102 requires certain metadata attributes which are used to geolocate the dataset as well as establish a pedigree for the data.
 
 The elements are related in a metadata Schema and include definitions and extension procedures. There exist both mandatory and conditional metadata elements. Only a few metadata elements are mandatory but the inclusion of some of the optional metadata elements establish a situation where other metadata elements are conditionally made mandatory.
 
-<<tab-s102-handling-of-core-metadata-elements>> outlines the core metadata elements (mandatory and recommended optional) required for describing a geographic information data set. The codes indicate: "M" mandatory, "O" optional' "C" conditional as defined in <<iso19115>>. <<tab-s102-handling-of-core-metadata-elements>> indicates how the mandatory, optional and conditional core metadata are handled in S-102.
+<<tab-s102-handling-of-core-metadata-elements>> outlines the core metadata elements (mandatory and recommended optional) required for describing a geographic information data set. The codes indicate: "M" mandatory, "O" optional' "C" conditional as defined in <<iso-19115-1>>. <<tab-s102-handling-of-core-metadata-elements>> indicates how the mandatory, optional and conditional core metadata are handled in S-102.
 
 [[tab-s102-handling-of-core-metadata-elements]]
 .S-102 Handling of Core Metadata Elements
@@ -87,7 +87,7 @@ Implicit in S-102 product specification reference to
 
 |*Dataset character set \(C)*
 
-set to default = "utf8". [not required when set to default from <<iso19115>>]
+set to default = "utf8". [not required when set to default from <<iso-19115-1>>]
 
 from: (MD_Metadata.identificationInfo > MD_DataIdentification.defaultLocale > PT_Locale.characterEncoding)
 
@@ -176,7 +176,7 @@ from: (MD_Metadata.metadataScope > MD_MetadataScope.resourceScope > MD_ScopeCode
 
 |===
 
-The dataset metadata is stored in a separate file encoded according to the ISO 19115X Schemas. The name of the metadata file is MD_<HDF5 data file base name>.XML (or .xml) ISO metadata (per <<iho-s100,part=10c,clause=10c-12>>), The root element in the file is *S102_DSMetadataBlock* which contains *S102_DS_DiscoveryMetadata*, *S102_StructureMetadataBlock* and *S102_QualityMetadataBlock*. 
+The dataset metadata is stored in a separate file encoded according to the ISO 19115X Schemas. The name of the metadata file is MD_<HDF5 data file base name>.XML (or .xml) ISO metadata (per <<iho-s100,part=10c,clause=10c-12>>), The root element in the file is *S102_DSMetadataBlock* which contains *S102_DS_DiscoveryMetadata*, *S102_StructureMetadataBlock* and *S102_QualityMetadataBlock*.
 
 [[subsec-discovery-metadata]]
 === Discovery metadata
@@ -196,13 +196,13 @@ Chair has larger action to ensure correspondence between all figures and all tex
 image::figure-s102-discovery-metadata.png[]
 
 
-<<fig-s102-discovery-metadata>> above shows the *S102_DiscoveryMetadataBlock*. It has one subtype S102_DS_DiscoveryMetadata. This implements the metadata classes from <<iso19115>>. First implementation classes have been developed corresponding to each of the <<iso19115>> classes that have been referenced in which only the applicable attributes have been included. The class *S102_DS_DiscoveryMetadata* inherits attributes from S-102 specific implementation classes. In addition, an additional component *S102_DataIdentification* has been added.
+<<fig-s102-discovery-metadata>> above shows the *S102_DiscoveryMetadataBlock*. It has one subtype S102_DS_DiscoveryMetadata. This implements the metadata classes from <<iso-19115-1>>. First implementation classes have been developed corresponding to each of the <<iso-19115-1>> classes that have been referenced in which only the applicable attributes have been included. The class *S102_DS_DiscoveryMetadata* inherits attributes from S-102 specific implementation classes. In addition, an additional component *S102_DataIdentification* has been added.
 
-This model provides the minimum amount of metadata for a Bathymetry Surface data product. Any of the additional optional metadata elements from the source <<iso19115>> metadata standard can also be included.
+This model provides the minimum amount of metadata for a Bathymetry Surface data product. Any of the additional optional metadata elements from the source <<iso-19115-1>> metadata standard can also be included.
 
-<<tab-sample-contents-of-the-two-dimensional-bathymetrycoverage-array>> provides a description of each attribute of the S102_DiscoveryMetadataBlock class attributes.
+<<tab-discoverymetadablock-class-attributes>> provides a description of each attribute of the S102_DiscoveryMetadataBlock class attributes.
 
-[[discoverymetadablock-class-attributes]]
+[[tab-discoverymetadablock-class-attributes]]
 .S102_DiscoveryMetadataBlock class attributes
 [cols="a,a,a,^a,a,a",options="header",cols="1,3,2,1,3,3"]
 |===
@@ -317,7 +317,7 @@ otherLocale need be populated only if the dataset uses more than one language
 
 |Class
 |S102_DataIdentification
-|Component for S102_DiscoveryMeta data Block. Extension beyond <<iso19115>> metadata
+|Component for S102_DiscoveryMeta data Block. Extension beyond <<iso-19115-1>> metadata
 |-
 |-
 |
@@ -339,7 +339,7 @@ otherLocale need be populated only if the dataset uses more than one language
 |===
 
 
-The class *S102_DataIdentification* provides an extension to the metadata available from <<iso19115>>. The verticalUncertaintyType attribute was added to accurately describe the source and meaning of the encoded Uncertainty coverage. The depthCorrectionType was also added to define if and how the depths are corrected (that is, true depth, depth ref 1500 m/sec, etc.). <<tab-code-defining-the-type-of-sound-velocity-correction>> and <<tab-code-defining-how-uncertainty-was-determined>> provide a description.
+The class *S102_DataIdentification* provides an extension to the metadata available from <<iso-19115-1>>. The verticalUncertaintyType attribute was added to accurately describe the source and meaning of the encoded Uncertainty coverage. The depthCorrectionType was also added to define if and how the depths are corrected (that is, true depth, depth ref 1500 m/sec, etc.). <<tab-code-defining-the-type-of-sound-velocity-correction>> and <<tab-code-defining-how-uncertainty-was-determined>> provide a description.
 
 
 [[tab-code-defining-the-type-of-sound-velocity-correction]]
@@ -379,9 +379,9 @@ NOTE: As stated in <<cls-1.3>>, uncertainty is always considered to be 1-dimensi
 === Structure metadata
 Structure metadata is used to describe the structure of an instance of a collection. Since constraints can be different on separate files (for example they could be derived from different legal sources), or security constraints may be different, the constraint information becomes part of the structure metadata. The other structure metadata is the grid representation and the reference system.
 
-<<fig-s102-structure-metadata>> shows the *S102_StructureMetadataBlock*. The metadata block is generated by the inheritance of attributes from a number of <<iso19115>> metadata classes and from two implementation classes for the horizontal and vertical reference system. This makes the metadata block a simple table.
+<<fig-s102-structure-metadata>> shows the *S102_StructureMetadataBlock*. The metadata block is generated by the inheritance of attributes from a number of <<iso-19115-1>> metadata classes and from two implementation classes for the horizontal and vertical reference system. This makes the metadata block a simple table.
 
-Metadata in *S102_StructureMetadataBlock* is encoded within a separate metadata xml file under the *S102_MetadataBlock* root element. 
+Metadata in *S102_StructureMetadataBlock* is encoded within a separate metadata xml file under the *S102_MetadataBlock* root element.
 
 
 [[fig-s102-structure-metadata]]
@@ -442,7 +442,7 @@ Mandatory and must be 1.
 
 
 ==== Quality metadata
-Quality metadata is used to describe the quality of the data in an instance of a collection. <<fig-s102-quality-metadata>> shows the *S102_QualityMetadataBlock*. The *S102_QualityMetadataBlock* derives directly from the <<iso19115>> class *DQ_DataQuality*. However, its components *S102_LI_Source* and *S102_LI_ProcessStep* are generated by the inheritance of attributes from the <<iso19115>> classes *LI_Scope* and *LI_ProcessStep*. Only some of the attributes of the referenced <<iso19115>> classes are implemented.
+Quality metadata is used to describe the quality of the data in an instance of a collection. <<fig-s102-quality-metadata>> shows the *S102_QualityMetadataBlock*. The *S102_QualityMetadataBlock* derives directly from the <<iso-19115-1>> class *DQ_DataQuality*. However, its components *S102_LI_Source* and *S102_LI_ProcessStep* are generated by the inheritance of attributes from the <<iso-19115-1>> classes *LI_Scope* and *LI_ProcessStep*. Only some of the attributes of the referenced <<iso-19115-1>> classes are implemented.
 
 Metadata in *S102_QualityMetadataBlock* is encoded within a separate metadata xml file under the *S102_MetadataBlock* root element.
 
@@ -559,12 +559,12 @@ Chair has action to ensure that PT at-large is happy with the removal of "or 'ti
 
 
 ==== Acquisition metadata
-Acquisition metadata to a Bathymetric Surface Product Specification profile is being developed nationally. The classes derive from <<iso19115>>, <<iso-19115-2>>, <<iso-ts-19130>> and <<iso-ts-19130-2>>. The later document <<iso-ts-19130-2>> contains description of sonar parameters.
+Acquisition metadata to a Bathymetric Surface Product Specification profile is being developed nationally. The classes derive from <<iso-19115-1>>, <<iso-19115-2>>, <<iso-ts-19130>> and <<iso-ts-19130-2>>. The later document <<iso-ts-19130-2>> contains description of sonar parameters.
 
 === Exchange Set metadata
 For information exchange, there are several categories of metadata required: metadata about the overall Exchange Catalogue, metadata about each of the datasets contained in the Catalogue.
 
-<<fig-realization-of-the-exchange-set-classes>>, <<fig-s102-exchange-set-catalogue>>, <<fig-s102-exchange-set>> and <<fig-s102-exchange-set-class-details>> outline the overall concept of an S-102 Exchange Set for the interchange of geospatial data and its relevant metadata. <<fig-realization-of-the-exchange-set-classes>> depicts the realization of the <<iso19139>> classes which form the foundation of the Exchange Set. The overall structure of S-102 metadata for Exchange Sets is modelled in <<fig-s102-exchange-set-catalogue>> and <<fig-s102-exchange-set>>. More detailed information about the various classes is shown in <<fig-s102-exchange-set-class-details>> and a textual description in <<tab-s102-exchangeCatalogue-params;to!tab-pt-locale-params>>.
+<<fig-realization-of-the-exchange-set-classes>>, <<fig-s102-exchange-set-catalogue>>, <<fig-s102-exchange-set>> and <<fig-s102-exchange-set-class-details>> outline the overall concept of an S-102 Exchange Set for the interchange of geospatial data and its relevant metadata. <<fig-realization-of-the-exchange-set-classes>> depicts the realization of the <<iso-19139-1>> classes which form the foundation of the Exchange Set. The overall structure of S-102 metadata for Exchange Sets is modelled in <<fig-s102-exchange-set-catalogue>> and <<fig-s102-exchange-set>>. More detailed information about the various classes is shown in <<fig-s102-exchange-set-class-details>> and a textual description in <<tab-s102-exchangeCatalogue-params;to!tab-pt-locale-params>>.
 
 The discovery metadata classes have numerous attributes which enable important information about the datasets to be examined without the need to process the data, for example, decrypt, decompress, load etc. Other Catalogues can be included in the Exchange Set in support of the datasets such as Feature and Portrayal.
 

--- a/sources/2.2.0/sections/12-metadata.adoc
+++ b/sources/2.2.0/sections/12-metadata.adoc
@@ -250,7 +250,7 @@ Required items are Citation.title, & Citation.date,
 |Identification of, and means of communication with, person(s) and organization(s) associated with the resource(s)
 |1
 |CI_Responsibility
-|See <<iho-s100,part=4a,table=4a-2>> and <<<<iho-s100,part=4a,table=4a-3>> for required items
+|See <<iho-s100,part=4a,table=4a-2>> and <<iho-s100,part=4a,table=4a-3>> for required items
 
 |attribute
 |spatialRepresentationType
@@ -286,7 +286,7 @@ If this attribute is present, the four bounding box sub-attributes westBoundLong
 |Organisation responsible for the metadata information
 |1
 |CI_Responsibility>CI_Organisation
-|See <<iho-s100,part=4a,table=4a-2>> and <<<<iho-s100,part=4a,table=4a-3>> for required items
+|See <<iho-s100,part=4a,table=4a-2>> and <<iho-s100,part=4a,table=4a-3>> for required items
 
 |attribute
 |dateInfo


### PR DESCRIPTION
As requested per @hasel001 , this PR fixes all previously problematic cross-references.

In addition, I have converted partially encoded cross-references like these:
```adoc
<<iho-s100,part=10c>>, Table 6
```

Into:
```adoc
<<iho-s100,part=10c,table=6>>
```

For semantic availability.