### PR TITLE
Whitelist for vertical datum

### DIFF
--- a/sources/2.3.0/sections/10-data_product_format.adoc
+++ b/sources/2.3.0/sections/10-data_product_format.adoc
@@ -436,10 +436,8 @@ The only allowed value is 1: s100VerticalDatum +
 unsigned +
 16-bit
 | Numeric code from IHO GI Registry +
-_Vertical Datum_ attribute except +
-*47 (seaFloor) +
-*48 (seaSurface) +
-*49 (hydrographicZero).
+_Vertical Datum_ attribute +
+stem:[1-41] & stem:[43-46]
 
 |===
 


### PR DESCRIPTION
During PT15 it was decided that there should be a whitelist for the vertical datum.
The list has now been created.