### PR TITLE
approximateGridResolution remarks & note: remove parts of ungeorectified grid, variable cell size grid

### DIFF
--- a/sources/3.0.0/sections/12-metadata.adoc
+++ b/sources/3.0.0/sections/12-metadata.adoc
@@ -604,7 +604,9 @@ S-102 uses S100_DataCoverage without modification.
 |*Mandatory in S-102* +
 A single value may be provided when all axes have a common resolution. +
 For multiple value provision, use axis order as specified in dataset. +
-For example, for 5-metre resolution, the value 5 must be encoded.
+For example, for 5-metre resolution, the value 5 must be encoded. +
+If the grid cell size varies over the extent of the grid +
+(i.e., when using a geographic grid), an approximated value should be used.
 |===
 
 ==== S100_Purpose

--- a/sources/3.0.0/sections/12-metadata.adoc
+++ b/sources/3.0.0/sections/12-metadata.adoc
@@ -604,18 +604,8 @@ S-102 uses S100_DataCoverage without modification.
 |*Mandatory in S-102* +
 A single value may be provided when all axes have a common resolution. +
 For multiple value provision, use axis order as specified in dataset. +
-May be approximate for ungeorectified data (*not applicable to this edition of S-102*). +
-For example, for 5-metre resolution, the value 5 must be encoded. +
-See note immediately below.
-
+For example, for 5-metre resolution, the value 5 must be encoded.
 |===
-[[s100-dataCoverage-params-note1]]
-[NOTE]
-====
-If the grid cell size varies over the extent of the grid, an approximated value based on model parameters or production metadata should be used.
-====
-
-
 
 ==== S100_Purpose
 [[tab-s100-purpose]]


### PR DESCRIPTION
1. Table 20 — S100_DataCoverage parameters, approximateGridResolution, Remarks:

Remove sentence _May be approximate for ungeorectified data (not applicable to this edition of S-102)._

2. Table 20 — S100_DataCoverage parameters, Remove Note: 

_NOTE: If the grid cell size varies over the extent of the grid, an approximated value based on model parameters or production metadata should be used._