### PR TITLE
Fix GitHub Actions build

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -22,12 +22,12 @@ jobs:
       image: metanorma/metanorma:latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 
       - name: Metanorma generate site
-        uses: actions-mn/build-and-publish@v1
+        uses: actions-mn/build-and-publish@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           agree-to-terms: true


### PR DESCRIPTION
The [build-and-publish](https://github.com/actions-mn/build-and-publish) action has been upgraded to [v2](https://github.com/actions-mn/build-and-publish/tree/v2).

This commit fixes the automated build.